### PR TITLE
Fix IE embed and vertical centering of preview

### DIFF
--- a/jquery.webcam.js
+++ b/jquery.webcam.js
@@ -164,7 +164,7 @@ jQuery(function($) {
         width:      Math.max(this.options.previewWidth, this.options.previewHeight * vratio),
         height:     Math.max(this.options.previewHeight, this.options.previewWidth / vratio),
         marginLeft: Math.min(0, - (this.options.previewHeight * vratio - this.options.previewWidth) / 2),
-        marginTop:  Math.min(0, - (this.options.previewWidth / vratio - this.options.previewWidth) / 2)
+        marginTop:  Math.min(0, - (this.options.previewWidth / vratio - this.options.previewHeight) / 2)
       })
       var pratio = this.options.previewWidth / this.options.previewHeight
       this.$canvas.attr({

--- a/jquery.webcam.js
+++ b/jquery.webcam.js
@@ -49,32 +49,32 @@ jQuery(function($) {
       this.id = this.setUid(this.$element)
       this.options = this.getOptions(options)
       var callTarget = "jQuery('#" + this.id + "').data('webcam')"
+      var flashvars = $.param({
+          callTarget: callTarget,
+          resolutionWidth: this.options.resolutionWidth,
+          resolutionHeight: this.options.resolutionHeight,
+          smoothing: this.options.videoSmoothing,
+          deblocking: this.options.videoDeblocking,
+          StageScaleMode: this.options.stageScaleMode,
+          StageAlign: this.options.stageAlign
+      })
+      var embed = '<object id="'+this.id+'Object" type="application/x-shockwave-flash" data="'+this.options.swffile+'" ' +
+            'width="'+this.options.previewWidth+'" height="'+this.options.previewHeight+'">' +
+          '<param name="movie" value="'+this.options.swffile+'" />' +
+          '<param name="FlashVars" value="' + flashvars + '" />' +
+          '<param name="bgcolor" value="'+this.options.bgcolor+'" />' +
+          '<param name="allowScriptAccess" value="always" />' +
+          '<param name="wmode" value="opaque" />' +
+          '</object>'
 
-      this.$cam = $('<object>', {
-          type: 'application/x-shockwave-flash',
-          data: this.options.swffile,
-          width: this.options.previewWidth,
-          height: this.options.previewHeight
-        }).append(
-          $('<param>', { name: 'movie', value: this.options.swffile }),
-          $('<param>', { name: 'allowScriptAccess', value: 'always' }),
-          $('<param>', { name: 'bgcolor', value: this.options.bgcolor }),
-          $('<param>', { name: 'FlashVars', value: $.param({
-              callTarget: callTarget,
-              resolutionWidth: this.options.resolutionWidth,
-              resolutionHeight: this.options.resolutionHeight,
-              smoothing: this.options.videoSmoothing,
-              deblocking: this.options.videoDeblocking,
-              StageScaleMode: this.options.stageScaleMode,
-              StageAlign: this.options.stageAlign
-            })
-          }))
+      this.$cam = $(embed)
 
       this.$element.append(this.$cam)
       this.cam = this.$cam[0]
     },
     cameraConnected: function () {
       this.isSwfReady = true
+      this.cam = document.getElementById(this.id + 'Object')
       this.cameraReady()
     },
 
@@ -352,7 +352,7 @@ jQuery(function($) {
        */
       stageAlign: 'TL',
 
-      swffile: "sAS3Cam.swf",
+      swffile: "sAS3Cam.swf"
     })
   }
 


### PR DESCRIPTION
This is fixing embed code to work in IE9. IE8 still won't work because of flash trying to attach callbacks `play` and `stop` which seems to be reserved words in IE8.
Second commit fixing vertical centering which looks like a little typo.

Btw, thanks for great fork!
